### PR TITLE
chore: update bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2767,7 +2767,7 @@
 
     "@stripe/stripe-react-native": ["@stripe/stripe-react-native@0.55.0", "", { "peerDependencies": { "expo": ">=46.0.9", "react": "*", "react-native": "*" }, "optionalPeers": ["expo"] }, "sha512-9vOlgCoBmmcYYJk2HpRCTzA6X7hMyOuKQZt0ZTRLIVqODIhUqIn1E8mXKhHYlHTseQ44TcCqNVJvZtricRtd7Q=="],
 
-    "@stripe/stripe-terminal-react-native": ["@stripe/stripe-terminal-react-native@0.0.1-beta.31", "", { "dependencies": { "base-64": "^1.0.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-7f7c3++jVF/h664QN+ENr7NcKN+yyp/ccG5n9dNrIf1smENIALSCtFKyA79xO+q9LmT2s5da6TtJN785KEd5Tw=="],
+    "@stripe/stripe-terminal-react-native": ["@stripe/stripe-terminal-react-native@0.0.1-beta.32", "", { "dependencies": { "base-64": "^1.0.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ujIik80yhfHx56SNg0sWm6iEXCXIs+miM6Mb2VaxEkX0xEVA44vYkzt6JFh0n9iScN2WXOXSBc3pvrkuYCTW2A=="],
 
     "@superfan-app/spotify-auth": ["@superfan-app/spotify-auth@0.1.73", "", { "dependencies": { "@expo/config-plugins": "^10.1.2" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-t3JOyJzXtNWNBMMH8Rc1M5lHtxnhqQvcQjFshf3x/Cs8A3HZH3UV1ATxijPRsoALRPFes0ISmQoqjX5GJ3ILzA=="],
 


### PR DESCRIPTION
Refreshes `bun.lock` so it matches the current dependency manifests.

Single resolution change:

- `@stripe/stripe-terminal-react-native`: `0.0.1-beta.31` → `0.0.1-beta.32`

No changes to `package.json`.

### Note on how the lockfile was generated

A plain `bun install` cannot complete in this environment: `packageList` pulls in `@divvi/mobile`, whose peer dep `react-native-contacts` resolves to a GitHub tarball (`github:valora-inc/react-native-contacts#9940121`), and this session's egress policy returns 403 for GitHub tarball hosts outside the current repo's scope. The lockfile was therefore regenerated with `bun install --lockfile-only`, which resolves dependencies without downloading them. The result is stable across repeated runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3NDKPVwHTZN3AzQm4mKvv)_